### PR TITLE
`manifold.markets/api/v0` -> `api.manifold.markets/v0`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,7 @@ import { Bet, FullMarket, LiteMarket } from './types'
 
 const yourKey = process.env.MANIFOLD_API_KEY
 
-const API_URL = 'https://manifold.markets/api/v0'
+const API_URL = 'https://api.manifold.markets/v0'
 
 export const getFullMarket = async (id: string) => {
   const market: FullMarket = await fetch(`${API_URL}/market/${id}`).then(


### PR DESCRIPTION
Self-explanatory.